### PR TITLE
Feature/modify base manifest sample

### DIFF
--- a/config/base_manifest.yaml
+++ b/config/base_manifest.yaml
@@ -40,7 +40,7 @@ spec:
     provider: "slack"
     secretName: "gatling-notification-slack-secrets"
   testScenarioSpec:
-    parallelism: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
+    parallelism: 1 # <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
     simulationClass: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.simulationClass field value. ex: SampleSimulation
     env: # will be overrided by services[].scenarioSpecs[].testScenarioSpec.env[] field value. ex: `env: [{name: ENV, value: "dev"}, {name: CONCURRENCY, value: "20"}]`
       - name: <config.yaml overrides this field>

--- a/docs/quickstart-guide.jp.md
+++ b/docs/quickstart-guide.jp.md
@@ -173,7 +173,7 @@ spec:
     provider: "slack"
     secretName: "gatling-notification-slack-secrets"
   testScenarioSpec:
-    parallelism: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
+    parallelism: 1 # <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
     simulationClass: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.simulationClass field value. ex: SampleSimulation
     env: # will be overrided by services[].scenarioSpecs[].testScenarioSpec.env[] field value. ex: `env: [{name: ENV, value: "dev"}, {name: CONCURRENCY, value: "20"}]`
       - name: <config.yaml overrides this field>

--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -173,7 +173,7 @@ spec:
     provider: "slack"
     secretName: "gatling-notification-slack-secrets"
   testScenarioSpec:
-    parallelism: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
+    parallelism: 1 # <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.parallelism field value. ex: 1
     simulationClass: <config.yaml overrides this field> # will be overrided by services[].scenarioSpecs[].testScenarioSpec.simulationClass field value. ex: SampleSimulation
     env: # will be overrided by services[].scenarioSpecs[].testScenarioSpec.env[] field value. ex: `env: [{name: ENV, value: "dev"}, {name: CONCURRENCY, value: "20"}]`
       - name: <config.yaml overrides this field>

--- a/docs/user-guide.jp.md
+++ b/docs/user-guide.jp.md
@@ -96,9 +96,14 @@ serviceは同一の負荷試験対象に関する1つ以上の負荷試験シナ
 `base_manifest.yaml`にはGatlingリソースのKubernetesマニフェストのうち、負荷試験ごとに共通する値を設定するフィールドを記述します。  
 GatlingリソースのKubernetesマニフェストのフィールドについては、[Gatling OperatorのAPI Reference](https://github.com/st-tech/gatling-operator/blob/main/docs/api.md#gatling)を参照してください。
 
-`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに異なる値が設定されます。  
-これらのフィールドの値は、Gatling Commanderの実行時に`config.yaml`の値でそれぞれ置き換えられます。  
-そのため、`base_manifest.yaml`での値の変更は不要です。
+`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに異なる値が設定されます。これらのフィールドの値は、Gatling Commanderの実行時に`config.yaml`の値でそれぞれ置き換えられます。そのため、`base_manifest.yaml`での値の変更は不要です。
+
+※ Gatling Commanderは`base_manifest.yaml`の値を`config.yaml`の値で置き換える前に、一度GoのGatling構造体のオブジェクトにその値を読み込みます。そのため、`base_manifest.yaml`の各フィールドの値の型はGatling構造体の各フィールドの値の型と一致する必要があります。型が一致しない場合次のようなエラーが発生します。
+
+```go
+json: cannot unmarshal string into Go struct field TestScenarioSpec.spec.testScenarioSpec.parallelism of type int32
+```
+
 
 `base_manifest.yaml`のうち、`config.yaml`の値で置き換えられるフィールドについて説明します。
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -27,8 +27,13 @@ Configuration values for the load test are written in `config/config.yaml`.
 
 The `base_manifest.yaml` describes the common values for each load test in the Kubernetes manifest of the Gatling Resource.
 
-Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each load test. The value of this field will be replaced by the value in `config.yaml` respectively when Gatling Commander runs.
-Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
+Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each load test. The value of this field will be replaced by the value in `config.yaml` respectively when Gatling Commander runs. Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
+
+\* Gatling Commander once loads `base_manifest.yaml` value to Gatling struct object before it replaces the value by `config.yaml`. So the type of `base_manifest.yaml` field value must be matched to Gatling struct field one. If type not match, an error like following error will be occured.
+
+```go
+json: cannot unmarshal string into Go struct field TestScenarioSpec.spec.testScenarioSpec.parallelism of type int32
+```
 
 The location and file name of `config.yaml` and `base_manifest.yaml` can be any value.  
 For the `config.yaml` path, specify the value of the `--config` option when executing the command.  

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,7 +29,7 @@ The `base_manifest.yaml` describes the common values for each load test in the K
 
 Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each load test. The value of this field will be replaced by the value in `config.yaml` respectively when Gatling Commander runs. Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
 
-\* Gatling Commander once loads `base_manifest.yaml` value to Gatling struct object before it replaces the value by `config.yaml`. So the type of `base_manifest.yaml` field value must be matched to Gatling struct field one. If type not match, an error like following error will be occured.
+\* Gatling Commander once loads `base_manifest.yaml` value to Gatling struct object before it replaces the value by `config.yaml`. So the type of `base_manifest.yaml` field value must be matched to Gatling struct field one. If type not match, an error like following occur.
 
 ```go
 json: cannot unmarshal string into Go struct field TestScenarioSpec.spec.testScenarioSpec.parallelism of type int32


### PR DESCRIPTION
### Description

- modify sample `config/base_manifest.yaml` parallelism field value.
- add explanation about type matching between `config/base_manifest.yaml` and Gatling struct field in related docs.

### Checklist

_Please check if applicable_

- [x] Tests have been added (if applicable, ie. when cli codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)
