### PR TITLE
update docs about gatling manifest patch more specific

### DIFF
--- a/docs/quickstart-guide.jp.md
+++ b/docs/quickstart-guide.jp.md
@@ -121,8 +121,7 @@ Gatling CommanderではGatling Operatorで利用するKubernetesのCustom Resour
 `base_manifest.yaml`はGatlingリソースのKubernetesマニフェストです。  
 `base_manifest.yaml`にはGatlingリソースについて、負荷試験ごとに共通の値を記述します。
 
-`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに異なる値が設定されます。こちらのフィールドの値は、Gatling Commanderの実行時に`config.yaml`の値でそれぞれ置き換えられます。  
-そのため`base_manifest.yaml`での値の設定は不要です。
+`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに`config.yaml`の値で上書きされます。そのため、`base_manifest.yaml`の値を変更する事なく複数の負荷試験を連続して実行できます。
 
 `config/base_manifest.yaml`の記述については、[Gatling Operatorのサンプル](https://github.com/st-tech/gatling-operator/blob/main/config/samples/gatling-operator_v1alpha1_gatling01.yaml)を参考に、利用する環境に合わせて作成してください。  
 詳細については[User Guide](./user-guide.jp.md)を参照してください。

--- a/docs/quickstart-guide.md
+++ b/docs/quickstart-guide.md
@@ -121,8 +121,7 @@ Gatling Commander creates an object for a Gatling Resource, a Kubernetes Custom 
 The `base_manifest.yaml` is Kubernetes manifest for Gatling Resource.  
 The `base_manifest.yaml` has the common values for each load test for the Gatling Resource.
 
-Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each loadtest. The value of this field will be replaced by the corresponding value in `config.yaml` respectively when Gatling Commander is run.  
-Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
+Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are overwritten by `config.yaml` value for each load test. Therefore, multiple loadtests can be run consecutively without changing the value of `base_manifest.yaml`.
 
 For information on how to write Kubernetes manifest for Gatling Resource (`config/base_manifest.yaml`), see the [samples YAML file](https://github.com/st-tech/gatling-operator/blob/main/config/samples/gatling-operator_v1alpha1_gatling01.yaml) which is provided in st-tech/gatling-operator repository, and create manifest for your environment.
 

--- a/docs/user-guide.jp.md
+++ b/docs/user-guide.jp.md
@@ -25,8 +25,7 @@ Gatling Commanderでは、設定ファイルとして次の2種類のYAMLファ�
 
 `base_manifest.yaml`にはGatlingリソースのKubernetesマニフェストのうち、負荷試験ごとに共通の値を記述します。
 
-`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに異なる値が設定されます。こちらのフィールドの値は、Gatling Commanderの実行時に`config.yaml`の値でそれぞれ置き換えられます。  
-そのため`base_manifest.yaml`での値の設定は不要です。
+`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに`config.yaml`の値で上書きされます。そのため、`base_manifest.yaml`の値を変更する事なく複数の負荷試験を連続して実行できます。
 
 `config.yaml`・`base_manifest.yaml`の保存場所、ファイル名は任意の値を指定可能です。  
 参照する`config.yaml`のパスについては、コマンド実行時に`--config`オプションの値を指定してください。  
@@ -96,7 +95,7 @@ serviceは同一の負荷試験対象に関する1つ以上の負荷試験シナ
 `base_manifest.yaml`にはGatlingリソースのKubernetesマニフェストのうち、負荷試験ごとに共通する値を設定するフィールドを記述します。  
 GatlingリソースのKubernetesマニフェストのフィールドについては、[Gatling OperatorのAPI Reference](https://github.com/st-tech/gatling-operator/blob/main/docs/api.md#gatling)を参照してください。
 
-`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに異なる値が設定されます。これらのフィールドの値は、Gatling Commanderの実行時に`config.yaml`の値でそれぞれ置き換えられます。そのため、`base_manifest.yaml`での値の変更は不要です。
+`base_manifest.yaml`に`<config.yaml overrides this field>`と記載があるフィールドは、負荷試験ごとに`config.yaml`の値で上書きされます。そのため、`base_manifest.yaml`でこれらのフィールドの値は変更不要です。
 
 ※ Gatling Commanderは`base_manifest.yaml`の値を`config.yaml`の値で置き換える前に、一度GoのGatling構造体のオブジェクトにその値を読み込みます。そのため、`base_manifest.yaml`の各フィールドの値の型はGatling構造体の各フィールドの値の型と一致する必要があります。型が一致しない場合次のようなエラーが発生します。
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -27,7 +27,7 @@ Configuration values for the load test are written in `config/config.yaml`.
 
 The `base_manifest.yaml` describes the common values for each load test in the Kubernetes manifest of the Gatling Resource.
 
-Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each load test. The value of this field will be replaced by the value in `config.yaml` respectively when Gatling Commander runs. Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
+Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are overwritten by `config.yaml` value for each load test. Therefore, multiple loadtests can be run consecutively without changing the value of `base_manifest.yaml`.
 
 \* Gatling Commander once loads `base_manifest.yaml` value to Gatling struct object before it replaces the value by `config.yaml`. So the type of `base_manifest.yaml` field value must be matched to Gatling struct field one. If type not match, an error like following occur.
 
@@ -103,8 +103,7 @@ This section describes the configuration values in `config.yaml` for each indivi
 The `base_manifest.yaml` describes the fields in the Kubernetes manifest of the Gatling Resource that set common values for each load test.  
 For more information about the fields in the Kubernetes manifest of the Gatling Resource, see [Gatling Operator API Reference](https://github.com/st-tech/gatling-operator/blob/main/docs/api.md#gatling).
 
-Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are set to different values for each loadtest. The value of this field will be replaced by the corresponding value in `config.yaml` respectively when Gatling Commander is run.  
-Therefore, setting values to fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` is not necessary.
+Fields marked `<config.yaml overrides this field>` in `base_manifest.yaml` are overwritten by `config.yaml` value for each load test. Therefore, the values of these fields don't need to be changed in `base_manifest.yaml`.
 
 This section describes the fields in `base_manifest.yaml` that are replaced by values in `config.yaml`.
 


### PR DESCRIPTION
### Description

- Update the explanation for overwriting some field values in `base_manifest.yaml` by `config.yaml`.

### Checklist

- [x] Tests have been added (if applicable, ie. when cli codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

Relevant issue 
comment https://github.com/st-tech/gatling-commander/pull/5#discussion_r1451893145 in https://github.com/st-tech/gatling-commander/pull/5.