### PR TITLE
update ubuntu version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   check-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -35,7 +35,7 @@ jobs:
           args: --timeout=10m
 
   check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
### Description

Update ubuntu version from 20.04 to 24.04 with Github Actions.
Because ubuntu 20.04 support will end in April 2025.

### Checklist

_Please check if applicable_

- [x] Tests have been added (if applicable, ie. when cli codes are added or modified)
- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)

