### PR TITLE
hotfix: enable decimal number for concurrency and update Gatling Dockerfile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.53
+          version: v1.57
           args: --timeout=10m
 
   check-test:

--- a/gatling/Dockerfile
+++ b/gatling/Dockerfile
@@ -1,31 +1,34 @@
 # This is modified based on the original file:
 # https://github.com/denvazh/gatling/tree/master/3.2.1
+# And refer to https://github.com/st-tech/gatling-operator/blob/afab1b88fa9c2517792c0456d064699906619de4/gatling/Dockerfile
 #
-# Gatling is a highly capable load test tool.
-#
-# Documentation: https://gatling.io/docs/3.2/
-# Cheat sheet: https://gatling.io/docs/3.2/cheat-sheet/
+# Gatling is a highly capable load testing tool.
 
-FROM --platform=linux/x86_64 openjdk:8-jdk-alpine
+FROM openjdk:21-ea-21-jdk-slim-bullseye
+
+# create user/group
+RUN groupadd -g 1000 gatling && \
+  useradd -l -u 1000 -m gatling -g gatling
 
 # working directory for gatling
 WORKDIR /opt
 
 # gating version
-ENV GATLING_VERSION 3.2.1
+ENV GATLING_VERSION 3.10.5
 
 # create directory for gatling install
 RUN mkdir -p gatling
 
 # install gatling
-RUN apk add --update wget bash libc6-compat && \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y wget unzip &&  \
   mkdir -p /tmp/downloads && \
   wget -q -O /tmp/downloads/gatling-$GATLING_VERSION.zip \
   https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/$GATLING_VERSION/gatling-charts-highcharts-bundle-$GATLING_VERSION-bundle.zip && \
   mkdir -p /tmp/archive && cd /tmp/archive && \
   unzip /tmp/downloads/gatling-$GATLING_VERSION.zip && \
   mv /tmp/archive/gatling-charts-highcharts-bundle-$GATLING_VERSION/* /opt/gatling/ && \
-  rm -rf /opt/gatling/user-files/simulations/computerdatabase /tmp/*
+  rm -rf /opt/gatling/user-files/simulations/computerdatabase /tmp/*  && \
+  chown -R gatling:gatling /opt/gatling
 
 # change context to gatling directory
 WORKDIR  /opt/gatling

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/st-tech/gatling-commander
 
-go 1.20
+go 1.22.2
 
 require (
 	cloud.google.com/go/storage v1.30.1

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -105,6 +106,7 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -163,6 +165,7 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -174,6 +177,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.4 h1:1kZ/sQM3srePvKs3tXAvQzo66XfcReoqFpIpIccE7Oc=
 github.com/google/s2a-go v0.1.4/go.mod h1:Ej+mSEMGRnqRzjc7VtF+jdBwYG5fuJfiZ8ELkjEwM0A=
@@ -213,6 +217,7 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -234,7 +239,9 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.9.5 h1:+6Hr4uxzP4XIUyAkg61dWBw8lb/gc4/X5luuxN/EC+Q=
+github.com/onsi/ginkgo/v2 v2.9.5/go.mod h1:tvAoo1QUJwNEU2ITftXTpR7R1RbCzoZUOs3RonqW57k=
 github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
+github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -255,6 +262,7 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
@@ -305,6 +313,7 @@ go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=

--- a/pkg/internal/gatling/report.go
+++ b/pkg/internal/gatling/report.go
@@ -96,11 +96,11 @@ func ExtractLoadtestConditionToReport(
 		case "DURATION":
 			duration = field.Value
 		case "CONCURRENCY":
-			singleConcurrency, err := strconv.Atoi(field.Value)
+			singleConcurrency, err := strconv.ParseFloat(field.Value, 64)
 			if err != nil {
 				return "", "", "", err
 			}
-			concurrency = fmt.Sprintf("%v", testScenarioSpec.Parallelism*int32(singleConcurrency))
+			concurrency = strconv.FormatFloat(float64(testScenarioSpec.Parallelism)*singleConcurrency, 'f', -1, 64)
 		default:
 			condition += fmt.Sprintf("%v=%v,", field.Name, field.Value)
 		}

--- a/pkg/internal/gatling/report_test.go
+++ b/pkg/internal/gatling/report_test.go
@@ -31,6 +31,7 @@ import (
 
 	gatlingv1alpha1 "github.com/st-tech/gatling-operator/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestGetPercentileLatency_Success(t *testing.T) {
@@ -114,6 +115,94 @@ func TestGetPercentileLatency_Fail(t *testing.T) {
 			latency, err := SampleReport.GetPercentileLatency(tt.input)
 			assert.Equal(t, tt.expected, err)
 			assert.Equal(t, float64(0), latency)
+		})
+	}
+}
+
+func TestExtractLoadtestConditionToReport(t *testing.T) {
+	tests := []struct {
+		name                string
+		testScenarioSpec    gatlingv1alpha1.TestScenarioSpec
+		expectedConcurrency string
+		expectedDuration    string
+		expectedCondition   string
+		expectError         bool
+	}{
+		{
+			name: "integer concurrency",
+			testScenarioSpec: gatlingv1alpha1.TestScenarioSpec{
+				Parallelism: 3,
+				Env: []corev1.EnvVar{
+					{Name: "CONCURRENCY", Value: "25"},
+					{Name: "DURATION", Value: "60"},
+				},
+			},
+			expectedConcurrency: "75",
+			expectedDuration:    "60",
+			expectedCondition:   "",
+		},
+		{
+			name: "decimal concurrency",
+			testScenarioSpec: gatlingv1alpha1.TestScenarioSpec{
+				Parallelism: 1,
+				Env: []corev1.EnvVar{
+					{Name: "CONCURRENCY", Value: "0.1"},
+					{Name: "DURATION", Value: "30"},
+				},
+			},
+			expectedConcurrency: "0.1",
+			expectedDuration:    "30",
+			expectedCondition:   "",
+		},
+		{
+			name: "decimal concurrency resulting in integer",
+			testScenarioSpec: gatlingv1alpha1.TestScenarioSpec{
+				Parallelism: 2,
+				Env: []corev1.EnvVar{
+					{Name: "CONCURRENCY", Value: "1.5"},
+					{Name: "DURATION", Value: "60"},
+				},
+			},
+			expectedConcurrency: "3",
+			expectedDuration:    "60",
+			expectedCondition:   "",
+		},
+		{
+			name: "with extra env vars as condition",
+			testScenarioSpec: gatlingv1alpha1.TestScenarioSpec{
+				Parallelism: 1,
+				Env: []corev1.EnvVar{
+					{Name: "CONCURRENCY", Value: "0.5"},
+					{Name: "DURATION", Value: "120"},
+					{Name: "RAMP_DURATION", Value: "10"},
+				},
+			},
+			expectedConcurrency: "0.5",
+			expectedDuration:    "120",
+			expectedCondition:   "RAMP_DURATION=10,",
+		},
+		{
+			name: "invalid concurrency value",
+			testScenarioSpec: gatlingv1alpha1.TestScenarioSpec{
+				Parallelism: 1,
+				Env: []corev1.EnvVar{
+					{Name: "CONCURRENCY", Value: "abc"},
+				},
+			},
+			expectError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			concurrency, duration, condition, err := ExtractLoadtestConditionToReport(tt.testScenarioSpec)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedConcurrency, concurrency)
+				assert.Equal(t, tt.expectedDuration, duration)
+				assert.Equal(t, tt.expectedCondition, condition)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Description

- Enable decimal number specification for CONCURRENCY env var (e.g. `0.1`) by replacing `strconv.Atoi` with `strconv.ParseFloat`.
- Update Gatling Dockerfile to align with [gatling-operator](https://github.com/st-tech/gatling-operator/blob/main/gatling/Dockerfile).
  - Base image: `openjdk:8-jdk-alpine` → `openjdk:21-ea-21-jdk-slim-bullseye`
  - Gatling version: `3.2.1` → `3.10.5`
  - Package manager: `apk` → `apt-get`
  - Add `gatling` user/group (uid/gid 1000)
- Update Go version from `1.20` to `1.22.2`.

### Checklist

- [x] Tests have been added (if applicable, ie. when cli codes are added or modified)
- [ ] When specifying concurrency, I confirmed that type casting errors no longer occur and results can be written to the spreadsheet.
<img width="757" height="87" alt="スクリーンショット 2026-02-27 18 21 16" src="https://github.com/user-attachments/assets/79db37e9-cfb1-4837-b50f-66b874d2b67e" />

- [x] Relevant docs have been added or modified (if applicable, ie. when new features are added or current features are modified)